### PR TITLE
fix `OpenAgendaSdk::getMyAgendasUids` when used with invalid API Key

### DIFF
--- a/src/OpenAgendaSdk.php
+++ b/src/OpenAgendaSdk.php
@@ -82,6 +82,11 @@ class OpenAgendaSdk
   public function getMyAgendasUids(): array
   {
     $agendas = json_decode($this->getMyAgendas());
+
+    if ($agendas->error) {
+      return [];
+    }
+
     if (!array_key_exists('items', $agendas)) {
       return [];
     }

--- a/tests/AgendaTest.php
+++ b/tests/AgendaTest.php
@@ -30,4 +30,14 @@ class AgendaTest extends TestCase
         $this->assertNotNull($agenda->uid);
         $this->assertIsInt($agenda->uid);
     }
+
+    /**
+     * @throws OpenAgendaSdkException
+     * @test
+     */
+    public function testGetMyAgendasUids() {
+        $data = HelperTest::getOa('invalid-key', 'GET')->getMyAgendasUids();
+        $this->assertIsArray($data);
+        $this->assertEmpty($data);
+    }
 }

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,4 +1,10 @@
 {
+  "invalid-key": {
+    "GET": {
+      "body": "mocks/invalid/key.json",
+      "path": "/agendas?key=mypublickey"
+    }
+  },
   "agenda": {
     "GET": {
       "body": "mocks/agenda/agenda.json",

--- a/tests/mocks/invalid/key.json
+++ b/tests/mocks/invalid/key.json
@@ -1,0 +1,4 @@
+{
+  "success": false,
+  "message": "invalid key"
+}


### PR DESCRIPTION
In order to fix #1 we should properly handle the `error` array 

It's testable easily by removing my own fix code and running the new added test

This fix will also improve the user experience on the Drupal companion module `drupal/openagenda` as when creating an Open Agenda node without a valid API Key, proper message will be displayed instead of broken interface.

### 📸 Screenshots

#### Before the fix, Drupal without working API Key

<img width="1904" alt="Screenshot 2022-07-26 at 11 59 47" src="https://user-images.githubusercontent.com/1841592/180979737-846de9eb-3535-4344-9f4b-d8fcfde05f00.png">

#### After the fix, Drupal without working API Key

<img width="1904" alt="180977250-357eddce-918c-46c4-a4a9-266e2fd43fa1" src="https://user-images.githubusercontent.com/1841592/180978878-b803f267-1c2c-4db2-a4c7-3817c24a3739.png">
