### PR TITLE
PHP 8 compatibility - fix usage of `array_key_exists` after `json_decode `non-associative for PHP 8

### DIFF
--- a/src/OpenAgendaSdk.php
+++ b/src/OpenAgendaSdk.php
@@ -75,8 +75,8 @@ class OpenAgendaSdk
    */
   public function getMyAgendasUids(): array
   {
-    $agendas = \json_decode($this->getMyAgendas());
-    if (!\array_key_exists('items', $agendas)) {
+    $agendas = \json_decode($this->getMyAgendas(), false);
+    if (!\property_exists($agendas, 'items')) {
       return [];
     }
 


### PR DESCRIPTION
fix usage of `array_key_exists` after `json_decode `non-associative for PHP 8
